### PR TITLE
Support usage of `invalid?` and `validate!` methods from `ActiveModel::Validations`

### DIFF
--- a/lib/active_resource/validations.rb
+++ b/lib/active_resource/validations.rb
@@ -160,7 +160,7 @@ module ActiveResource
     #   my_person.valid?
     #   # => false
     #
-    def valid?
+    def valid?(context = nil)
       run_callbacks :validate do
         super
         load_remote_errors(@remote_errors, true) if defined?(@remote_errors) && @remote_errors.present?

--- a/test/cases/validations_test.rb
+++ b/test/cases/validations_test.rb
@@ -56,6 +56,18 @@ class ValidationsTest < ActiveSupport::TestCase
     assert_equal ["is too long (maximum is 10 characters)"], project.errors[:description]
   end
 
+  def test_invalid_method
+    p = new_project
+
+    assert_not p.invalid?
+  end
+
+  def test_validate_bang_method
+    p = new_project(name: nil)
+
+    assert_raise(ActiveModel::ValidationError) { p.validate! }
+  end
+
   protected
     # quickie helper to create a new project with all the required
     # attributes.


### PR DESCRIPTION
## What

Allows `invalid?` and `validate!` methods from `ActiveModel::Validations` to work.

## Why

Due to the overridden `valid?` method not taking into account the [save context feature from more recent versions of `ActiveModel`](https://github.com/rails/rails/blob/54a28244089e69d5350ba1203c65c867c1e8a640/activemodel/lib/active_model/validations.rb#L334), without this change, using those methods will raise: 

```
ArgumentError: wrong number of arguments (given 1, expected 0)
```

## How

Simply adds the `(context = nil)` argument to the method signature of `valid?`.